### PR TITLE
Fixed GCC warnings

### DIFF
--- a/tests/url_parser/test.cpp
+++ b/tests/url_parser/test.cpp
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <getopt.h>
 #include <stdlib.h>
-#include <string.h>
+#include <cstring>
 #include <inttypes.h>
 #include <coda/url.hpp>
 #include <coda/url_parser.hpp>
@@ -169,7 +169,7 @@ int main(int argc, char **argv)
     int i;
 
     urlq_getopt_t opts;
-    memset(&opts, 0, sizeof(opts));
+    std::memset(static_cast<void*>(&opts), 0, sizeof(opts));
 
     if (0 != urlq_getopt_parse(argc, argv, &opts))
     {


### PR DESCRIPTION
```
/home/ruslan/projects/coda/tests/url_parser/test.cpp: In function ‘int main(int, char**)’:
/home/ruslan/projects/coda/tests/url_parser/test.cpp:172:34: error: ‘void* memset(void*, int, size_t)’ clearing an object of type ‘urlq_getopt_t’ {aka ‘struct urlq_getopt’} with no trivial copy-assignment; use assignment or value-initialization instead [-Werror=class-memaccess]
     memset(&opts, 0, sizeof(opts));
                                  ^
/home/ruslan/projects/coda/tests/url_parser/test.cpp:21:8: note: ‘urlq_getopt_t’ {aka ‘struct urlq_getopt’} declared here
```